### PR TITLE
Minor cleanup

### DIFF
--- a/src/Dir.hs
+++ b/src/Dir.hs
@@ -107,16 +107,16 @@ listAndJoin :: FilePath -> IO [FilePath]
 listAndJoin path = fmap (path </>) <$> (liftIO $ listDirectory' path)
 
 getAllFiles :: (MonadIO m, MonadReader App m) => [FilePath] -> m [ScriptFileData]
-getAllFiles kjDirs = concat <$> mapM getAllFiles' kjDirs
-  where getAllFiles' kjDir = do
-          exists <- liftIO $ doesDirectoryExist kjDir
+getAllFiles kjDirs = concat <$> mapM getAllFilesPerDirectory kjDirs
+  where getAllFilesPerDirectory dir = do
+          exists <- liftIO $ doesDirectoryExist dir
           if not exists
             then return []
             else do
-            fullPaths <- liftIO $ listAndJoin kjDir
+            fullPaths <- liftIO $ listAndJoin dir
             filesOnly <- liftIO $ sort <$> filterM (doesFileExist) fullPaths
             dirsOnly <- liftIO $ sort <$> filterM (doesDirectoryExist) fullPaths
-            nestedFiles <- concat <$> mapM getAllFiles' dirsOnly
+            nestedFiles <- concat <$> mapM getAllFilesPerDirectory dirsOnly
             return $ (mapMaybe fromString) filesOnly ++ nestedFiles
 
 getAllPossibleKjDirs :: (MonadIO m, MonadReader App m) => FilePath -> m [FilePath]

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -33,13 +33,12 @@ instance Options KjOptions where
 main :: IO ()
 main = do
   app <- runCommand $ \opts args -> do
-    let runMode = if (optDetailOnly opts)
-               then RunMode_Detail
-               else if (optListOnly opts)
-                    then RunMode_List
-                    else if (optCatFile opts)
-                         then RunMode_Cat
-                         else RunMode_Execute
+    let runMode
+          | optDetailOnly opts = RunMode_Detail
+          | optListOnly opts = RunMode_List
+          | optCatFile opts = RunMode_Cat
+          | otherwise = RunMode_Execute
+
     return App { _app_runMode = runMode
                , _app_verbose = optVerbose opts
                , _app_autoRestart = optAutoRestart opts

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -15,21 +15,6 @@ import Control.Monad.Trans
 import Control.Monad.Reader
 
 
-instance Options KjOptions where
-    defineOptions =
-      pure KjOptions
-      <*> mkViewOpt "list" "Print all available scripts (in machine readable format)"
-      <*> mkViewOpt "detail" "Print all available scripts (with docstring if available)"
-      <*> mkViewOpt "cat" "display contents of script"
-      <*> mkViewOpt "auto-restart" "automatically restart script when it terminates"
-      <*> mkViewOpt "verbose" "run in verbose mode"
-      where mkViewOpt long desc =
-              defineOption optionType_bool
-              (\o -> o { optionLongFlags = [long],
-                         optionShortFlags = [head long],
-                         optionDescription = desc,
-                         optionDefault = False })
-
 main :: IO ()
 main = do
   app <- runCommand $ \opts args -> do

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -1,14 +1,32 @@
 module Types where
 
--- this type is just used for parsing command line options
--- they are processed into an `App`, which gets passed around
--- to lower-level functions.
+import Options
+
+
+--- this type is just used for parsing command line options
+--- they are processed into an `App`, which gets passed around
+--- to lower-level functions.
 data KjOptions = KjOptions { optListOnly :: Bool
                            , optDetailOnly :: Bool
                            , optCatFile :: Bool
                            , optAutoRestart :: Bool
                            , optVerbose :: Bool
                            }
+
+instance Options KjOptions where
+    defineOptions =
+      pure KjOptions
+      <*> mkViewOpt "list" "Print all available scripts (in machine readable format)"
+      <*> mkViewOpt "detail" "Print all available scripts (with docstring if available)"
+      <*> mkViewOpt "cat" "display contents of script"
+      <*> mkViewOpt "auto-restart" "automatically restart script when it terminates"
+      <*> mkViewOpt "verbose" "run in verbose mode"
+      where mkViewOpt long desc =
+              defineOption optionType_bool
+              (\o -> o { optionLongFlags = [long],
+                         optionShortFlags = [head long],
+                         optionDescription = desc,
+                         optionDefault = False })
 
 data RunMode = RunMode_List
              | RunMode_Detail
@@ -21,5 +39,3 @@ data App = App
   , _app_verbose :: Bool
   , _app_args :: [String]
   }
-
-


### PR DESCRIPTION
## Overview

This PR cleans up a few minor things, including:
 * Flattening out `runMode` using guards instead of nested if/else blocks
 * Renaming `kjDir` in one place, since it was shadowing the `kjDir` function in `KjConfig`
 * Moving `KjOptions` back to Main in order to un-orphan the instance
 * Propagating the `MonadReader` constraint to various functions in order to avoid passing around `App` and calling `runReaderT` multiple times